### PR TITLE
libassuan socket emulation file support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ ssh-agent-adapter.VC.db
 int
 bin
 .vs
+*.vcxproj.user
+.vscode

--- a/common.c
+++ b/common.c
@@ -9,6 +9,9 @@ static void con_activity_done(connection* con) {
 		CloseHandle(con->np2uds_th);
 		CloseHandle(con->uds2np_th);
 		free(con);
+		if (debug_mode != 0) {
+			printf("connection closed\n");
+		}
 	}
 }
 
@@ -33,25 +36,45 @@ DWORD WINAPI uds2np_thread(LPVOID param) {
 		ZeroMemory(&ol, sizeof(OVERLAPPED));
 		// read from pipe
 		if (!ReadFileEx(con->pipe, buf, BUFSIZE, &ol, apc_callback)) {
+			if (debug_mode != 0) {
+				printf("couldn't start read from pipe\n");
+			}
 			goto done;
 		}
 		
 		SleepEx(INFINITE, TRUE);
 		bytes_read = 0;
-		if (con->abort_io || !GetOverlappedResult(con->pipe, &ol, &bytes_read, FALSE))
+		if (con->abort_io || !GetOverlappedResult(con->pipe, &ol, &bytes_read, FALSE)) {
+			if (debug_mode != 0) {
+				printf("couldn't get bytes from pipe, or read aborted\n");
+			}
 			goto done;
+		}
+		if (debug_mode != 0) {
+			printf("read %d bytes from pipe\n", bytes_read);
+		}
 
 		//now write to sock
 		bytes_written = 0;
 		while (bytes_written < bytes_read) {
 			int written = send(con->sock, buf + bytes_written, bytes_read - bytes_written, 0);
-			if (written == SOCKET_ERROR)
+			if (written == SOCKET_ERROR) {
+				if (debug_mode != 0) {
+					printf("error when writing to socket\n");
+				}
 				goto done;
+			}
 			bytes_written += written;
+			if (debug_mode != 0) {
+				printf("wrote %d (%d) of %d bytes to socket\n", written, bytes_written, bytes_read);
+			}
 		}
 	}
 
 done:
+	if (debug_mode != 0) {
+		printf("shutting down socket\n");
+	}
 	shutdown(con->sock, SD_SEND);
 	con_activity_done(con);
 	return 0;
@@ -68,21 +91,42 @@ DWORD WINAPI np2uds_thread(LPVOID param) {
 	while (1) {
 		// read from sock
 		bytes_read = recv(con->sock, buf, BUFSIZE, 0);
-		if (bytes_read <= 0)
+		if (bytes_read <= 0) {
+			if (debug_mode != 0) {
+				printf("nothing to read from socket\n");
+			}
 			goto done;
+		}
+		if (debug_mode != 0) {
+			printf("read %d bytes from socket\n", bytes_read);
+		}
 
 		// now write to pipe
 		bytes_written = 0;
 		ZeroMemory(&ol, sizeof(OVERLAPPED));
-		if (!WriteFileEx(con->pipe, buf, bytes_read, &ol, apc_callback))
+		if (!WriteFileEx(con->pipe, buf, bytes_read, &ol, apc_callback)) {
+			if (debug_mode != 0) {
+				printf("can't start write to pipe\n");
+			}
 			goto done;
-			
+		}
+
 		SleepEx(INFINITE, TRUE);
-		if (!GetOverlappedResult(con->pipe, &ol, &bytes_written, FALSE))
+		if (!GetOverlappedResult(con->pipe, &ol, &bytes_written, FALSE)) {
+			if (debug_mode != 0) {
+				printf("couldn't write to pipe\n");
+			}
 			goto done;
+		}
+		if (debug_mode != 0) {
+			printf("wrote %d of %d bytes to pipe\n", bytes_written, bytes_read);
+		}
 	}
 
 done:
+	if (debug_mode != 0) {
+		printf("shutting down pipe\n");
+	}
 	QueueUserAPC(apc_abortio, con->uds2np_th, (ULONG_PTR)con);
 	con_activity_done(con);
 	return 0;

--- a/common.c
+++ b/common.c
@@ -9,9 +9,7 @@ static void con_activity_done(connection* con) {
 		CloseHandle(con->np2uds_th);
 		CloseHandle(con->uds2np_th);
 		free(con);
-		if (debug_mode != 0) {
-			printf("connection closed\n");
-		}
+		log("connection closed");
 	}
 }
 
@@ -36,45 +34,33 @@ DWORD WINAPI uds2np_thread(LPVOID param) {
 		ZeroMemory(&ol, sizeof(OVERLAPPED));
 		// read from pipe
 		if (!ReadFileEx(con->pipe, buf, BUFSIZE, &ol, apc_callback)) {
-			if (debug_mode != 0) {
-				printf("couldn't start read from pipe\n");
-			}
+			log("couldn't start read from pipe");
 			goto done;
 		}
 		
 		SleepEx(INFINITE, TRUE);
 		bytes_read = 0;
 		if (con->abort_io || !GetOverlappedResult(con->pipe, &ol, &bytes_read, FALSE)) {
-			if (debug_mode != 0) {
-				printf("couldn't get bytes from pipe, or read aborted\n");
-			}
+			log("couldn't get bytes from pipe, or read aborted");
 			goto done;
 		}
-		if (debug_mode != 0) {
-			printf("read %d bytes from pipe\n", bytes_read);
-		}
+		log("read %d bytes from pipe", bytes_read);
 
 		//now write to sock
 		bytes_written = 0;
 		while (bytes_written < bytes_read) {
 			int written = send(con->sock, buf + bytes_written, bytes_read - bytes_written, 0);
 			if (written == SOCKET_ERROR) {
-				if (debug_mode != 0) {
-					printf("error when writing to socket\n");
-				}
+				log("error when writing to socket");
 				goto done;
 			}
 			bytes_written += written;
-			if (debug_mode != 0) {
-				printf("wrote %d (%d) of %d bytes to socket\n", written, bytes_written, bytes_read);
-			}
+			log("wrote %d (%d) of %d bytes to socket", written, bytes_written, bytes_read);
 		}
 	}
 
 done:
-	if (debug_mode != 0) {
-		printf("shutting down socket\n");
-	}
+	log("shutting down socket");
 	shutdown(con->sock, SD_SEND);
 	con_activity_done(con);
 	return 0;
@@ -92,41 +78,29 @@ DWORD WINAPI np2uds_thread(LPVOID param) {
 		// read from sock
 		bytes_read = recv(con->sock, buf, BUFSIZE, 0);
 		if (bytes_read <= 0) {
-			if (debug_mode != 0) {
-				printf("nothing to read from socket\n");
-			}
+			log("nothing to read from socket");
 			goto done;
 		}
-		if (debug_mode != 0) {
-			printf("read %d bytes from socket\n", bytes_read);
-		}
+		log("read %d bytes from socket", bytes_read);
 
 		// now write to pipe
 		bytes_written = 0;
 		ZeroMemory(&ol, sizeof(OVERLAPPED));
 		if (!WriteFileEx(con->pipe, buf, bytes_read, &ol, apc_callback)) {
-			if (debug_mode != 0) {
-				printf("can't start write to pipe\n");
-			}
+			log("can't start write to pipe");
 			goto done;
 		}
 
 		SleepEx(INFINITE, TRUE);
 		if (!GetOverlappedResult(con->pipe, &ol, &bytes_written, FALSE)) {
-			if (debug_mode != 0) {
-				printf("couldn't write to pipe\n");
-			}
+			log("couldn't write to pipe");
 			goto done;
 		}
-		if (debug_mode != 0) {
-			printf("wrote %d of %d bytes to pipe\n", bytes_written, bytes_read);
-		}
+		log("wrote %d of %d bytes to pipe", bytes_written, bytes_read);
 	}
 
 done:
-	if (debug_mode != 0) {
-		printf("shutting down pipe\n");
-	}
+	log("shutting down pipe");
 	QueueUserAPC(apc_abortio, con->uds2np_th, (ULONG_PTR)con);
 	con_activity_done(con);
 	return 0;

--- a/common.h
+++ b/common.h
@@ -13,7 +13,7 @@
 #define DEFAULT_BUFLEN 512
 
 extern int debug_mode;
-#define log(...) {if (debug_mode) { printf(__VA_ARGS__); printf("\n");} } 
+#define log(...) {if (debug_mode!=0) { printf(__VA_ARGS__); printf("\n");} } 
 
 typedef struct _connection {
 	HANDLE pipe;

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -77,6 +77,9 @@ void process_pipe_connection(connection* con) {
 		printf("Only %d bytes of cookie could be sent (length=%d)\n", sc, cookie_len);
 		exit(1);
 	}
+	else {
+		printf("sent cookie to socket (length=%d)\n", sc);
+	}
 
 	//start threads
 	con->activity_count = 2;

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -46,6 +46,7 @@ errno_t process_sock_file(wchar_t* filename) {
 		free(cookie); cookie = NULL;
 	}
 	cookie = new_cookie;
+	cookie_len = clen;
 	return 0;
 
 	#undef SHORT_BUFLEN

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -75,6 +75,7 @@ void process_pipe_connection(connection* con) {
 int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
 {
 	wchar_t pipe_name[MAX_PATH], sock_name[MAX_PATH];
+	size_t sock_name_len;
 	errno_t err;
 	OVERLAPPED ol;
 	DWORD client_pid;
@@ -122,7 +123,10 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
 		}
 	}
 
-	//TODO - get value of SSH_AUTH_SOCK env variable and set as sock_name
+	if ((err =_wgetenv_s(&sock_name_len, &sock_name, MAX_PATH, L"SSH_AUTH_SOCK")) != 0) {
+		printf("couldn't get original socket path\n");
+		exit(err);
+	}
 	if ((err = process_sock_file(&sock_name)) != 0) {
 		printf("couldn't access socket %s\n", sock_name);
 		exit(err);

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -64,7 +64,8 @@ void process_pipe_connection(connection* con) {
 
 	connect(con->sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
 
-	//TODO - write cookie
+	// write cookie
+	send(con->sock, cookie, (int)cookie_len, 0);
 
 	//start threads
 	con->activity_count = 2;

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -36,7 +36,7 @@ errno_t process_sock_file(wchar_t* filename) {
 	if (new_cookie == NULL) {
 		return errno;
 	}
-	err = memcpy_s(new_cookie, clen, buf[i], clen);
+	err = memcpy_s(new_cookie, clen, &buf[i], clen);
 	if (err != 0) {
 		free(new_cookie); new_cookie = NULL;
 		return errno;
@@ -124,7 +124,7 @@ int wmain(int argc, wchar_t *argv[], wchar_t *envp[])
 		}
 	}
 
-	if ((err =_wgetenv_s(&sock_name_len, &sock_name, MAX_PATH, L"SSH_AUTH_SOCK")) != 0) {
+	if ((err =_wgetenv_s(&sock_name_len, &sock_name, MAX_PATH, L"SSH_AUTH_SOCK")) != 0 || sock_name[0] == 0) {
 		printf("couldn't get original socket path\n");
 		exit(err);
 	}

--- a/uds-2-np.c
+++ b/uds-2-np.c
@@ -66,6 +66,7 @@ void process_pipe_connection(connection* con) {
 
 	// write cookie
 	send(con->sock, cookie, (int)cookie_len, 0);
+	// TODO: anything else we need to do for handshake?
 
 	//start threads
 	con->activity_count = 2;


### PR DESCRIPTION
This takes care of processing the socket file to get the port and cookie, but even so the program still gets stuck sending the cookie across. With gpg-agent and uds-2-np running, and three attempts to do `ssh-add -l` (cancelled after 30s via Ctrl+C each time):

```
PS> .\uds-2-np.exe -d
incoming connections to pipe: \\.\pipe\usd-2-np-10596
will be routed to 127.0.0.1:5227
connection accepted from pid:14224
connection accepted from pid:25552
connection accepted from pid:10888
```

```
PS> gpg-agent -v --homedir ~\gnupg --use-standard-socket --enable-ssh-support --enable-putty-support --daemon --no-detach
gpg-agent[16064]: WARNING: "--use-standard-socket" is an obsolete option - it has no effect
gpg-agent[16064]: enabled debug flags: ipc
gpg-agent[16064]: listening on socket '~\gnupg\S.gpg-agent'
gpg-agent[16064]: listening on socket '~\gnupg\S.gpg-agent.extra'
gpg-agent[16064]: listening on socket '~\gnupg\S.gpg-agent.browser'
gpg-agent[16064]: listening on socket '~\gnupg\S.gpg-agent.ssh'
gpg-agent[16064]: gpg-agent (GnuPG) 2.2.4 started
gpg-agent[16064]: putty message loop thread started
gpg-agent[16064]: error reading nonce on fd 660: Input/output error
gpg-agent[16064]: error reading nonce on fd 740: Input/output error
gpg-agent[16064]: error reading nonce on fd 772: Input/output error
```

After looking into code for both gpg-agent and libassuan, it doesn't look like we need to send anything other than the cookie, and it doesn't look like we need to receive or acknowledge anything sent back before ssh-agent protocol can be used on the connection.